### PR TITLE
Add demographic charts

### DIFF
--- a/src/components/Charts/AgeChart/AgeChart.jsx
+++ b/src/components/Charts/AgeChart/AgeChart.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {useSelector} from 'react-redux';
+import {Doughnut} from 'react-chartjs-2';
+
+const AgeChart = () => {
+  const age_data = useSelector(state => state.data.age);
+
+  return (
+    <div className='age-chart-container'>
+      <div className='age-chart-title'>
+        <h5>Age</h5>
+      </div>
+      {age_data &&
+        <div className='age-charts'>
+          <div className='age-chart'>
+            <Doughnut
+              data = {{
+                labels: age_data.labels,
+                datasets: [
+                  {
+                    label: 'Cases',
+                    data: age_data.total_confirmed,
+                    backgroundColor: [
+                      '#a9a9a9',
+                      '#82c9e6',
+                      '#f3f5f4',
+                      '#f45060',
+                      '#f4d44d'
+                    ],
+                    borderColor: '#f3f5f4',
+                    borderWidth: 1
+                  }
+                ]
+              }}
+              options = {{
+                title: {
+                  display: true,
+                  text: 'Cases'
+                },
+                legend: {
+                  display: true,
+                  position: 'left'
+                }
+              }}
+            />
+          </div>
+          <div className='age-chart'>
+            <Doughnut
+              data = {{
+                labels: age_data.labels,
+                datasets: [
+                  {
+                    label: 'Deaths',
+                    data: age_data.total_confirmed,
+                    backgroundColor: [
+                      '#a9a9a9',
+                      '#82c9e6',
+                      '#f3f5f4',
+                      '#f45060',
+                      '#f4d44d'
+                    ],
+                    borderColor: '#f3f5f4',
+                    borderWidth: 1
+                  }
+                ]
+              }}
+              options = {{
+                title: {
+                  display: true,
+                  text: 'Deaths'
+                },
+                legend: {
+                  display: true,
+                  position: 'left'
+                }
+              }}
+            />
+          </div>
+        </div>
+      }
+    </div>
+  );
+};
+
+export default AgeChart;

--- a/src/components/Charts/AgeChart/AgeChart.jsx
+++ b/src/components/Charts/AgeChart/AgeChart.jsx
@@ -8,7 +8,7 @@ const AgeChart = () => {
   return (
     <div className='age-chart-container'>
       <div className='age-chart-title'>
-        <h5>Age (All CA)</h5>
+        <h5>Age (All–CA)</h5>
       </div>
       {age_data &&
         <div className='age-charts'>

--- a/src/components/Charts/CasesChart/CasesChart.jsx
+++ b/src/components/Charts/CasesChart/CasesChart.jsx
@@ -47,7 +47,7 @@ const CasesChart = () => {
               },
               zoom: {
                 enabled: true,
-                mode: 'xy'
+                // mode: 'x'
               },
               scales: {
                 xAxes: [{

--- a/src/components/Charts/Charts.jsx
+++ b/src/components/Charts/Charts.jsx
@@ -5,6 +5,7 @@ import CasesChart from './CasesChart/CasesChart';
 import DeathsChart from './DeathsChart/DeathsChart';
 import AgeChart from './AgeChart/AgeChart';
 import SexChart from './SexChart/SexChart';
+import EthnicityChart from './EthnicityChart/EthnicityChart';
 import {BeatLoader} from 'react-spinners';
 import './Charts.scss'
 
@@ -27,6 +28,7 @@ const Charts = () => {
             <div className='demographic-charts'>
               <AgeChart/>
               <SexChart/>
+              <EthnicityChart/>
             </div>
           </div>
         : <div className='beat-loader'>

--- a/src/components/Charts/Charts.jsx
+++ b/src/components/Charts/Charts.jsx
@@ -4,6 +4,7 @@ import {fetchAllData} from '../../store/actions';
 import CasesChart from './CasesChart/CasesChart';
 import DeathsChart from './DeathsChart/DeathsChart';
 import AgeChart from './AgeChart/AgeChart';
+import SexChart from './SexChart/SexChart';
 import {BeatLoader} from 'react-spinners';
 import './Charts.scss'
 
@@ -25,6 +26,7 @@ const Charts = () => {
             </div>
             <div className='demographic-charts'>
               <AgeChart/>
+              <SexChart/>
             </div>
           </div>
         : <div className='beat-loader'>

--- a/src/components/Charts/Charts.jsx
+++ b/src/components/Charts/Charts.jsx
@@ -3,6 +3,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import {fetchAllData} from '../../store/actions';
 import CasesChart from './CasesChart/CasesChart';
 import DeathsChart from './DeathsChart/DeathsChart';
+import AgeChart from './AgeChart/AgeChart';
 import {BeatLoader} from 'react-spinners';
 import './Charts.scss'
 
@@ -23,6 +24,7 @@ const Charts = () => {
               <DeathsChart/>
             </div>
             <div className='demographic-charts'>
+              <AgeChart/>
             </div>
           </div>
         : <div className='beat-loader'>

--- a/src/components/Charts/Charts.scss
+++ b/src/components/Charts/Charts.scss
@@ -73,6 +73,47 @@
         }
       }
     }
+
+    .sex-chart-container {
+      width: 100%;
+      border-bottom: 10px solid $primary-dark-color;
+  
+      .sex-chart-title {
+        padding: 0 2rem;
+        border-bottom: 1px solid $primary-light-color;
+      }
+  
+      .sex-charts {
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+
+        .sex-chart {
+          width: 100%;
+          margin-bottom: 20px;
+        }
+      }
+    }
+
+    .ethnicity-chart-container {
+      width: 100%;
+  
+      .ethnicity-chart-title {
+        padding: 0 2rem;
+        border-bottom: 1px solid $primary-light-color;
+      }
+  
+      .ethnicity-charts {
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+
+        .ethnicity-chart {
+          width: 100%;
+          margin-bottom: 20px;
+        }
+      }
+    }
   }
 }
 

--- a/src/components/Charts/Charts.scss
+++ b/src/components/Charts/Charts.scss
@@ -5,12 +5,12 @@
   background: $secondary-dark-color;
   margin: 2rem 4rem;
   display: flex;
+  height: 100vh;
 
   .time-charts {
     width: 60%;
-    overflow-x: hidden;
-    overflow-y: auto;
     border-right: 10px solid $primary-dark-color;
+    overflow-y: scroll;
 
     .cases-chart-container {
       width: 100%;
@@ -23,9 +23,11 @@
   
       .cases-chart {
         padding: 2rem;
+        // min-height: 40vh;
   
         canvas {
           width: 100% !important;
+          min-height: 40vh !important;
         }
       }
     }
@@ -43,6 +45,7 @@
   
         canvas {
           width: 100% !important;
+          min-height: 40vh !important;
         }
       }
     }
@@ -52,6 +55,7 @@
     width: 40%;
     display: flex;
     flex-direction: column;
+    overflow-y: scroll;
 
     .age-chart-container {
       width: 100%;
@@ -66,6 +70,8 @@
         padding: 2rem;
         display: flex;
         flex-direction: column;
+        // overflow-y: scroll;
+        // height: calc((100vh - (3 * ((1.5 * 2.2rem) + 1.2rem + 1px + (2 * 2rem))) - (2 * 10px)) / 3);
 
         .age-chart {
           width: 100%;
@@ -87,6 +93,8 @@
         padding: 2rem;
         display: flex;
         flex-direction: column;
+        // overflow-y: scroll;
+        // height: calc((100vh - (3 * ((1.5 * 2.2rem) + 1.2rem + 1px + (2 * 2rem))) - (2 * 10px)) / 3);
 
         .sex-chart {
           width: 100%;
@@ -107,6 +115,8 @@
         padding: 2rem;
         display: flex;
         flex-direction: column;
+        // overflow-y: scroll;
+        // height: calc((100vh - (3 * ((1.5 * 2.2rem) + 1.2rem + 1px + (2 * 2rem))) - (2 * 10px)) / 3);
 
         .ethnicity-chart {
           width: 100%;

--- a/src/components/Charts/Charts.scss
+++ b/src/components/Charts/Charts.scss
@@ -132,3 +132,24 @@
   margin-top: 30vh;
   text-align: center;
 }
+
+@media screen and (max-width: $breakpoint-tablet) {
+  .charts {
+    flex-direction: column;
+    height: auto;
+    
+    .time-charts {
+      width: 100%;
+      border-bottom: 10px solid $primary-dark-color;
+
+      .cases-chart-container>.cases-chart>canvas,
+      .deaths-chart-container>.deaths-chart>canvas {
+        min-height: 0 !important;
+      }
+    }
+
+    .demographic-charts {
+      width: 100%;
+    }
+  }
+}

--- a/src/components/Charts/Charts.scss
+++ b/src/components/Charts/Charts.scss
@@ -4,12 +4,17 @@
   width: 100%;
   background: $secondary-dark-color;
   margin: 2rem 4rem;
+  display: flex;
 
   .time-charts {
-    width: 100%;
+    width: 60%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    border-right: 10px solid $primary-dark-color;
 
     .cases-chart-container {
       width: 100%;
+      border-bottom: 10px solid $primary-dark-color;
   
       .cases-chart-title {
         padding: 0 2rem;
@@ -44,7 +49,30 @@
   }
 
   .demographic-charts {
+    width: 40%;
+    display: flex;
+    flex-direction: column;
 
+    .age-chart-container {
+      width: 100%;
+      border-bottom: 10px solid $primary-dark-color;
+  
+      .age-chart-title {
+        padding: 0 2rem;
+        border-bottom: 1px solid $primary-light-color;
+      }
+  
+      .age-charts {
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+
+        .age-chart {
+          width: 100%;
+          margin-bottom: 20px;
+        }
+      }
+    }
   }
 }
 

--- a/src/components/Charts/EthnicityChart/EthnicityChart.jsx
+++ b/src/components/Charts/EthnicityChart/EthnicityChart.jsx
@@ -2,28 +2,33 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 import {Doughnut} from 'react-chartjs-2';
 
-const SexChart = () => {
-  const sex_data = useSelector(state => state.data.sex);
+const EthnicityChart = () => {
+  const ethnicity_data = useSelector(state => state.data.ethnicity);
 
   return (
-    <div className='sex-chart-container'>
-      <div className='sex-chart-title'>
-        <h5>Sex (All–CA)</h5>
+    <div className='ethnicity-chart-container'>
+      <div className='ethnicity-chart-title'>
+        <h5>Ethnicity (All–CA)</h5>
       </div>
-      {sex_data &&
-        <div className='sex-charts'>
-          <div className='sex-chart'>
+      {ethnicity_data &&
+        <div className='ethnicity-charts'>
+          <div className='ethnicity-chart'>
             <Doughnut
               data = {{
-                labels: sex_data.labels,
+                labels: ethnicity_data.labels,
                 datasets: [
                   {
                     label: 'Cases',
-                    data: sex_data.total_confirmed,
+                    data: ethnicity_data.total_confirmed,
                     backgroundColor: [
-                      '#a9a9a9',
+                      '#f3f5f4',
+                      '#f4d44d',
                       '#82c9e6',
-                      '#f3f5f4'
+                      '#f45060',
+                      '#a9a9a9',
+                      '#ff939e',
+                      '#419be6',
+                      '#1e2130'
                     ],
                     borderColor: '#f3f5f4',
                     borderWidth: 1
@@ -42,18 +47,23 @@ const SexChart = () => {
               }}
             />
           </div>
-          <div className='sex-chart'>
+          <div className='ethnicity-chart'>
             <Doughnut
               data = {{
-                labels: sex_data.labels,
+                labels: ethnicity_data.labels,
                 datasets: [
                   {
                     label: 'Deaths',
-                    data: sex_data.total_deaths,
+                    data: ethnicity_data.total_deaths,
                     backgroundColor: [
-                      '#a9a9a9',
+                      '#f3f5f4',
+                      '#f4d44d',
                       '#82c9e6',
-                      '#f3f5f4'
+                      '#f45060',
+                      '#a9a9a9',
+                      '#ff939e',
+                      '#419be6',
+                      '#1e2130'
                     ],
                     borderColor: '#f3f5f4',
                     borderWidth: 1
@@ -78,4 +88,4 @@ const SexChart = () => {
   );
 };
 
-export default SexChart;
+export default EthnicityChart;

--- a/src/components/Charts/SexChart/SexChart.jsx
+++ b/src/components/Charts/SexChart/SexChart.jsx
@@ -2,30 +2,28 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 import {Doughnut} from 'react-chartjs-2';
 
-const AgeChart = () => {
-  const age_data = useSelector(state => state.data.age);
+const SexChart = () => {
+  const sex_data = useSelector(state => state.data.sex);
 
   return (
-    <div className='age-chart-container'>
-      <div className='age-chart-title'>
-        <h5>Age (All CA)</h5>
+    <div className='sex-chart-container'>
+      <div className='sex-chart-title'>
+        <h5>Sex (All CA)</h5>
       </div>
-      {age_data &&
-        <div className='age-charts'>
-          <div className='age-chart'>
+      {sex_data &&
+        <div className='sex-charts'>
+          <div className='sex-chart'>
             <Doughnut
               data = {{
-                labels: age_data.labels,
+                labels: sex_data.labels,
                 datasets: [
                   {
                     label: 'Cases',
-                    data: age_data.total_confirmed,
+                    data: sex_data.total_confirmed,
                     backgroundColor: [
-                      '#f3f5f4',
-                      '#f4d44d',
+                      '#a9a9a9',
                       '#82c9e6',
-                      '#f45060',
-                      '#a9a9a9'
+                      '#f3f5f4'
                     ],
                     borderColor: '#f3f5f4',
                     borderWidth: 1
@@ -44,20 +42,18 @@ const AgeChart = () => {
               }}
             />
           </div>
-          <div className='age-chart'>
+          <div className='sex-chart'>
             <Doughnut
               data = {{
-                labels: age_data.labels,
+                labels: sex_data.labels,
                 datasets: [
                   {
                     label: 'Deaths',
-                    data: age_data.total_deaths,
+                    data: sex_data.total_deaths,
                     backgroundColor: [
-                      '#f3f5f4',
-                      '#f4d44d',
+                      '#a9a9a9',
                       '#82c9e6',
-                      '#f45060',
-                      '#a9a9a9'
+                      '#f3f5f4'
                     ],
                     borderColor: '#f3f5f4',
                     borderWidth: 1
@@ -82,4 +78,4 @@ const AgeChart = () => {
   );
 };
 
-export default AgeChart;
+export default SexChart;

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -10,10 +10,6 @@ const Navbar = () => {
       </div>
       <div className='navbar-links'>
         <NavbarButton
-          text = 'About' 
-          href = '#statistics'
-        />
-        <NavbarButton
           text = 'Data' 
           href = 'https://data.ca.gov/dataset/covid-19-cases'
           target = '_blank'


### PR DESCRIPTION
Adds visualizations based on demographics instead of time-series. Includes:
* California-wide demographic doughnut charts (no data on Santa Clara specifically yet)
  * Cases and deaths based on age
  * Cases and deaths based on sex
  * Cases and deaths based on ethnicity
* Responsive layouts for tablet and mobile
* Removal of the "ABOUT" NavbarButton at the top